### PR TITLE
Fix IndexError type problem on ln1149, fix memory issue with leaving matplotlib open on multiple iterations.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,0 +1,43 @@
+- BugFix PyOMA_ver_1.4:
+  Error: "IndexError: invalid index into scalar variable. (ln:1149)"
+  Problem Description: >
+    Sometimes meanFi is just returning a numpy.complex128 (9.12e-9+1.6e-09j), 
+    but line 1149 tries to index-into meanFi for division (meanFi / meanFi[_idx6]).
+    This caused an 'IndexError' because numpy.complex128 is not an indexable
+    (enumerable) type.
+  Change:
+    - ln:24: >
+      +get_type = lambda object: str(type(object)).split("'")[1]
+    - Debug/Output:
+      Inserts: [1103, 1104, 1113, 1114, 1155, 1158]
+      changes: ln1149->ln1159 because of debug-inserts and blanklines for get_type()
+    - ln:1157: >
+      +meanFi = [meanFi] if not 'array' in get_type(meanFi) else meanFi
+  Solution Description: >
+    On line 1157 we check if meanFi is already an 'array' (enumerable), and do nothing
+    if it is. If it is not an 'array' then we surround it with square brackets,
+    making it enumerable. In all of my testing when meanFi is not an array _idx6
+    has been 0 (the first element of an enumerable), and so far this has been 
+    sufficient!
+- BugFix PyOMA_ver_1.4:
+  Warning: >
+    VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences
+    (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes)
+    is deprecated. If you meant to do this, you must specify 'dtype=object' when
+    creating the ndarray.   Fi = np.array(Fi_E)
+  Change:
+    ln:1266: +', dtype=object'
+  Solution Description: >
+    Create an ndarray from ragged nested sequences explicitly to prevent warning.
+- BugFix PyOMA_ver_1.4:
+  Warning: >
+    /tmp/tmp.FK7RnbM0cj/accelerometer_analysis/lib/pyoma.py:906: RuntimeWarning: 
+    More than 20 figures have been opened. Figures created through the pyplot interface
+    (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory.
+    (To control this warning, see the rcParam `figure.max_open_warning`).
+    Consider using `matplotlib.pyplot.close()`.
+  Change:
+    ln:907: +'plt.close()'
+  Solution Description: >
+    Close the `matplotlib.pyplot.figure` explicitly after saving the extracted data to fig, ax.
+

--- a/PyOMA_ver_1.4/PyOMA.py
+++ b/PyOMA_ver_1.4/PyOMA.py
@@ -904,6 +904,7 @@ def FDDsvp(data, fs, df=0.01, pov=0.5, window='hann'):
     
     # Plot of the singular values in log scale
     fig, ax = plt.subplots()
+    plt.close()
     for _i in range(nch):
     #    ax.semilogy(_f, S_val[_i, _i]) # scala log
         ax.plot(_f[:], 10*np.log10(S_val[_i, _i])) # decibel
@@ -1263,7 +1264,7 @@ $\xi$ = %.2f%s'''% (fn_EFDD, float(xi_EFDD)*100,"%"),transform=_ax4.transAxes)
     
     Freq = np.array(Freq_E)
     Damp = np.array(Damp_E)
-    Fi = np.array(Fi_E)
+    Fi = np.array(Fi_E, dtype=object)
 
     Results={}
     Results['Frequencies'] = Freq

--- a/PyOMA_ver_1.4/PyOMA.py
+++ b/PyOMA_ver_1.4/PyOMA.py
@@ -12,6 +12,7 @@ from scipy import signal
 from scipy.optimize import curve_fit
 import matplotlib.pyplot as plt
 from matplotlib.ticker import (MultipleLocator, FormatStrFormatter)
+# from lib.reply import reply  # Reply can be found https://github.com/briskbear/pymod (v0.1.0)
 import matplotlib.patches as patches
 import seaborn as sns
 import mplcursors
@@ -19,6 +20,8 @@ import mplcursors
 # =============================================================================
 # FUNZIONI PRONTE
 # =============================================================================
+
+get_type = lambda object: str(type(object)).split("'")[1]  # Return the type as a string. eg. 'list' not "<class 'list'>"
 
 def MaC(Fi1,Fi2):
     '''
@@ -1097,15 +1100,19 @@ def EFDDmodEX(FreQ, Results, ndf=2, MAClim=0.85, sppk=3, npmax=20,
         # checking if the MAC (with respect to the reference) satisfy 
         # MAC > MAClim
         # (N.B. this part of code should probably be improved!)
-        while MaC(_fi, S_vec_n[0,:, index[_l] + _p]) > MAClim: # here I check the FIRST singular vector
+        mac_out = MaC(_fi, S_vec_n[0,:, index[_l] + _p])
+#         reply(f'(S_vec_n[0...]) MAC > MAClim?: {mac_out} > {MAClim}', 'i', 'info.log')  # Debug: will 'while' run?
+        while mac_out > MAClim and (index[_l] + _p) < len(S_vec_n[0,:]): # here I check the FIRST singular vector
                  # collecting the singular values for EFDD
                 SDOFsval[(index[_l] + _p)] = S_val[0,0, index[_l] + _p]
                 # collecting singular values and applying FSDD
                 SDOFsval1[(index[_l] + _p)] = _fi.conj().T@PSD_matr[:,:, index[_l] + _p]@_fi 
                 # and the singular vectors
                 SDOFsvec[:,(index[_l] + _p)] = S_vec_n[0,:, index[_l] + _p] 
-                _p +=1
-        while MaC(_fi, S_vec_n[1,:, index[_l] + _p]) > MAClim: # here I check the SECOND singular vector
+                _p += 1
+        mac_out = MaC(_fi, S_vec_n[1,:, index[_l] + _p]) 
+#         reply(f'(S_vec_n[1...]) MAC > MAClim?: {mac_out} > {MAClim}', 'i', 'info.log')  # Debug: will 'while' run?
+        while mac_out > MAClim: # here I check the SECOND singular vector
                 SDOFsval[(index[_l] + _p)] = S_val[1,1, index[_l] + _p] # si aggiungono i relativi Singular values alla SFOF bell
                 SDOFsval1[(index[_l] + _p)] = _fi.conj().T@PSD_matr[:,:, index[_l] + _p]@_fi # si aggiungono i relativi Singular values alla SFOF bell
                 SDOFsvec[:,(index[_l] + _p)] = S_vec_n[1,:, index[_l] + _p] # e anche i relativi Singular vectors alla SFOF bell
@@ -1146,6 +1153,9 @@ def EFDDmodEX(FreQ, Results, ndf=2, MAClim=0.85, sppk=3, npmax=20,
         _idx6 = np.argmax(abs(meanFi))
         # Normalised mode shape (unity disp)
 #        meanFireal = meanFi.real/meanFi[_idx6].real 
+        # reply(meanFi, 'i', 'info.log')  # Debug: what does meanFi LOOK LIKE?
+        meanFi = [meanFi] if not 'array' in get_type(meanFi) else meanFi
+        # reply(meanFi, 'i', 'info.log')  # Debug: Is meanFi and array now?!
         meanFi = meanFi/meanFi[_idx6] 
         
         


### PR DESCRIPTION
…, fix IndexError(scaler) problem

   Sometimes `meanFi` is just returning a numpy.complex128 (9.12e-9+1.6e-09j), but line 1149 (1159 in my pull-request) tries to index-into `meanFi` for division (`meanFi / meanFi[_idx6]`). This caused an 'IndexError' because numpy.complex128 is not an indexable (enumerable) type.  
   
On line 1157 we check if `meanFi` is already an 'array' (enumerable), and do nothing if it is. If it is not an 'array' then we surround it with square brackets, making it enumerable. In all of my testing when `meanFi` is not an array `_idx6` has been 0 (the first element of an enumerable), and so far this has been sufficient!